### PR TITLE
Replaced fork by spawn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
 source "http://rubygems.org"
 
+group :test, :development do
+  # Use Rspec to test the app
+  gem "rspec-core"
+  gem "rspec-expectations"
+  gem "pry-rails"
+end
+
 # Specify your gem's dependencies in safe_shell.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,53 @@
 PATH
   remote: .
   specs:
-    safe_shell (1.0.1)
+    safe_shell (1.0.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    ffi (1.9.10-java)
+    method_source (0.8.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry (0.10.1-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    slop (3.6.0)
+    spoon (0.0.4)
+      ffi
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
+  pry-rails
   rspec
+  rspec-core
+  rspec-expectations
   safe_shell!
+
+BUNDLED WITH
+   1.10.6

--- a/lib/safe_shell.rb
+++ b/lib/safe_shell.rb
@@ -6,12 +6,8 @@ module SafeShell
     read_end, write_end = IO.pipe
     new_stdout = opts[:stdout] ? File.open(opts[:stdout], "w+") : write_end
     new_stderr = opts[:stderr] ? File.open(opts[:stderr], "w+") : write_end
-    pid = fork do
-      read_end.close
-      STDOUT.reopen(new_stdout)
-      STDERR.reopen(new_stderr)
-      exec(command, *(args.map { |a| a.to_s }))
-    end
+    opts = {:in => read_end, :out => new_stdout, :err => new_stderr}
+    pid = spawn(command, *(args.map { |a| a.to_s }), opts)
     write_end.close
     output = read_end.read
     Process.waitpid(pid)

--- a/spec/safe_shell_spec.rb
+++ b/spec/safe_shell_spec.rb
@@ -1,25 +1,26 @@
 require 'safe_shell'
+require "pry"
 
 describe "SafeShell" do
 
   it "should return the output of the command" do
-    SafeShell.execute("echo", "Hello, world!").should == "Hello, world!\n"
+    expect(SafeShell.execute("echo", "Hello, world!")).to eql("Hello, world!\n")
   end
 
   it "should safely handle dangerous characters in command arguments" do
-    SafeShell.execute("echo", ";date").should == ";date\n"
+    expect(SafeShell.execute("echo", ";date")).to eql(";date\n")
   end
 
   it "should set $? to the exit status of the command" do
     SafeShell.execute("test", "a", "=", "a")
-    $?.exitstatus.should == 0
+    expect($?.exitstatus).to eql(0)
 
     SafeShell.execute("test", "a", "=", "b")
-    $?.exitstatus.should == 1
+    expect($?.exitstatus).to eql(1)
   end
 
   it "should handle a Pathname object passed as an argument" do
-    expect { SafeShell.execute("ls", Pathname.new("/tmp")) }.should_not raise_error
+    expect { SafeShell.execute("ls", Pathname.new("/tmp")) }.not_to raise_error
   end
 
   context "output redirection" do
@@ -29,26 +30,26 @@ describe "SafeShell" do
 
     it "should let you redirect stdout to a file" do
       SafeShell.execute("echo", "Hello, world!", :stdout => "tmp/output.txt")
-      File.exists?("tmp/output.txt").should be_true
-      File.read("tmp/output.txt").should == "Hello, world!\n"
+      expect(File.exists?("tmp/output.txt")).to eql(true)
+      expect(File.read("tmp/output.txt")).to eql("Hello, world!\n")
     end
 
     it "should let you redirect stderr to a file" do
       SafeShell.execute("cat", "tmp/nonexistent-file", :stderr => "tmp/output.txt")
-      File.exists?("tmp/output.txt").should be_true
-      File.read("tmp/output.txt").should == "cat: tmp/nonexistent-file: No such file or directory\n"
+      expect(File.exists?("tmp/output.txt")).to eql(true)
+      expect(File.read("tmp/output.txt")).to eql("cat: tmp/nonexistent-file: No such file or directory\n")
     end
   end
 
   context ".execute!" do
     it "returns the output of the command" do
-      SafeShell.execute!("echo", "Hello, world!").should == "Hello, world!\n"
+      expect(SafeShell.execute!("echo", "Hello, world!")).to eql("Hello, world!\n")
     end
 
     it "raises an exception of the command fails" do
       expect {
         SafeShell.execute!("test", "a", "=", "b")
-      }.should raise_error(SafeShell::CommandFailedException)
+      }.to raise_error(SafeShell::CommandFailedException)
     end
   end
 

--- a/spec/safe_shell_spec.rb
+++ b/spec/safe_shell_spec.rb
@@ -1,5 +1,4 @@
 require 'safe_shell'
-require "pry"
 
 describe "SafeShell" do
 


### PR DESCRIPTION
I used the gem pdf-form to generate a pdf which uses SafeShell internally to create a subprocess for generating the pdf. This fails under jruby because SafeShell creates a subprocess by calling "fork" which is not available under jruby. I replaced fork with spawn which is a platform independent alternative for fork.