### PR TITLE
Adds the support for defining new env vars for the child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ SafeShell sets the $? operator to the process status, in the same manner as the 
 # Send stdout and stderr to files:
 SafeShell.execute("echo", "Hello, world!", :stdout => "output.txt", :stderr => "error.txt")
 
+# Send additional environment variables:
+SafeShell.execute("echo", "Hello, world!", :env => { 'name' => 'john', 'foo' => 'bar' })
+
 # Return true if the command exits with a zero status:
 SafeShell.execute?("echo", "Hello, world!")
 

--- a/lib/safe_shell.rb
+++ b/lib/safe_shell.rb
@@ -6,8 +6,15 @@ module SafeShell
     read_end, write_end = IO.pipe
     new_stdout = opts[:stdout] ? File.open(opts[:stdout], "w+") : write_end
     new_stderr = opts[:stderr] ? File.open(opts[:stderr], "w+") : write_end
+    env = opts[:env]
     opts = {:in => read_end, :out => new_stdout, :err => new_stderr}
-    pid = spawn(command, *(args.map { |a| a.to_s }), opts)
+
+    pid = if env
+      spawn(env, command, *(args.map { |a| a.to_s }), opts)
+    else
+      spawn(command, *(args.map { |a| a.to_s }), opts)
+    end
+
     write_end.close
     output = read_end.read
     Process.waitpid(pid)

--- a/lib/safe_shell/version.rb
+++ b/lib/safe_shell/version.rb
@@ -1,3 +1,3 @@
 module SafeShell
-  VERSION = "1.0.3"
+  VERSION = "1.1.0"
 end

--- a/spec/safe_shell_spec.rb
+++ b/spec/safe_shell_spec.rb
@@ -11,6 +11,11 @@ describe "SafeShell" do
     expect(SafeShell.execute("echo", ";date")).to eql(";date\n")
   end
 
+  it "allows to add new env vars" do
+    expect(SafeShell.execute('env')).to_not include("HELLO=world")
+    expect(SafeShell.execute('env', env: {'HELLO' => 'world'})).to include("HELLO=world")
+  end
+
   it "should set $? to the exit status of the command" do
     SafeShell.execute("test", "a", "=", "a")
     expect($?.exitstatus).to eql(0)

--- a/spec/safe_shell_spec.rb
+++ b/spec/safe_shell_spec.rb
@@ -12,8 +12,13 @@ describe "SafeShell" do
   end
 
   it "allows to add new env vars" do
-    expect(SafeShell.execute('env')).to_not include("HELLO=world")
-    expect(SafeShell.execute('env', env: {'HELLO' => 'world'})).to include("HELLO=world")
+    result = SafeShell.execute('env')
+    expect(result).to_not include("HELLO=world")
+    expect(result).to_not include("GOOD=world")
+
+    result = SafeShell.execute('env', env: {'HELLO' => 'world', 'GOOD' => 'day'})
+    expect(result).to include("HELLO=world")
+    expect(result).to include("GOOD=day")
   end
 
   it "should set $? to the exit status of the command" do


### PR DESCRIPTION
This change adds the support for passing extra env vars down to child processes.

```
bundle exec rspec spec
.........

Finished in 0.05356 seconds (files took 0.08425 seconds to load)
9 examples, 0 failures
```